### PR TITLE
FSD 패턴에 맞춰 Slider를 관리한다.

### DIFF
--- a/client/src/features/secretary/slider/ui/DateItem.tsx
+++ b/client/src/features/secretary/slider/ui/DateItem.tsx
@@ -1,0 +1,30 @@
+const DateItem = ({
+  date,
+  onClickDate,
+  onClickSlide,
+}: {
+  date: string;
+  onClickDate: (date: string) => void;
+  onClickSlide: (isOpen: boolean) => void;
+}): React.ReactElement => {
+  return (
+    <div
+      className="border-1 border-gray-300 rounded-lg justify-center gap-2 p-4"
+      onClick={() => {
+        onClickDate(date);
+        onClickSlide(false);
+      }}
+    >
+      <div className="flex flex-col justify-center gap-1">
+        <div className="text-lg font-bold">{date}</div>
+        <div className="text-sm font-medium text-gray-600">count 개 상품</div>
+      </div>
+      <div className="flex gap-2">
+        <div className="">총 이익</div>
+        <div className="font-bold text-green-600">이익 금액</div>
+      </div>
+    </div>
+  );
+};
+
+export default DateItem;

--- a/client/src/features/secretary/slider/ui/SliderItem.tsx
+++ b/client/src/features/secretary/slider/ui/SliderItem.tsx
@@ -1,0 +1,45 @@
+import { X } from "lucide-react";
+import useSecretaryContext from "@/views/secretary/context/useSecretaryContext";
+import { getUniqueSortedDates } from "@/shared/utils";
+import DateItem from "./DateItem";
+
+const SliderItem = (): React.ReactElement => {
+  const { isDateSlideOpen, setDateSlideOpen, setSelectedDate, ledgerData } =
+    useSecretaryContext();
+  return (
+    <>
+      {isDateSlideOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40"
+          onClick={() => setDateSlideOpen(false)}
+        />
+      )}
+      {/* 우측 슬라이드 패널 */}
+      <div
+        className={`flex flex-col fixed top-0 right-0 h-full overflow-y-auto w-[300px] bg-white transform transition-transform duration-300 ease-in-out z-50 p-2 gap-2 ${
+          isDateSlideOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex justify-between items-center p-3">
+          <div>날짜별 매출</div>
+          <div onClick={() => setDateSlideOpen(false)}>
+            <X className="w-5 h-5" />
+          </div>
+        </div>
+
+        {ledgerData &&
+          getUniqueSortedDates(ledgerData) &&
+          getUniqueSortedDates(ledgerData).map((date) => (
+            <DateItem
+              key={date}
+              date={date}
+              onClickDate={setSelectedDate}
+              onClickSlide={setDateSlideOpen}
+            />
+          ))}
+      </div>
+    </>
+  );
+};
+
+export default SliderItem;

--- a/client/src/views/secretary/SecretaryPage.tsx
+++ b/client/src/views/secretary/SecretaryPage.tsx
@@ -2,6 +2,7 @@
 
 import ProviderState from "./context/ProviderState";
 import HeaderTest from "@/features/secretary/header/Header.test";
+import SliderItem from "@/features/secretary/slider/ui/SliderItem";
 import InputFormTest from "@/widgets/secretary/input/presentational/InputForm.test";
 import "@/shared/lib/axios/axiosInterceptors";
 import FooterTest from "@/widgets/secretary/footer/presentational/Footer.test";
@@ -20,6 +21,7 @@ const SecretaryPage = (): React.ReactElement => {
       <InputFormTest />
       <DataRowListContainerTest todayUTC={todayUTC} />
       <FooterTest todayUTC={todayUTC} />
+      <SliderItem />
     </ProviderState>
   );
 };


### PR DESCRIPTION
- close : #44 

# Goal

- [x] Slider를 관리하는 Slider 영역을 FSD 패턴에 맞게 구현한다.

# Slider 컴포넌트 분리
현재 Slider 컴포넌트를 분리 했으나 완벽히 FSD 패턴에 맞게 구현되지 않았다. features와 widgets로 구분하기 이전에 현재 디테일한 기능 구현들이 먼저 진행이 되어야 PAPA 프로젝트가 가고자 하는 목표에 먼저 도달할 듯 싶다.
현재 task를 처리하는 과정은 다음과 같다.
```
[구현] -> [리팩토링/ 점검] -> [구현] -> [리팩토링/ 점검]
```

따라 우리의 목적은 실제 사용 서비스화, FSD 패턴 및 고도화 이다.

# 렌더링으로 인한 UIUX 시각적 부자연스러움
POST가 두번 발생하면서 DataTable의 렌더링이 이쁘지 않다. 이를 해결 할 수 있는 원인을 생각해 봐야한다.